### PR TITLE
fix(web): resolve related items popover cutoff and add fallback

### DIFF
--- a/apps/web/components/library/RelatedItemsBadge.test.tsx
+++ b/apps/web/components/library/RelatedItemsBadge.test.tsx
@@ -1,12 +1,21 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { RelatedItemsBadge } from './RelatedItemsBadge';
 import * as searchActions from '@/app/actions/search';
 
 vi.mock('@/app/actions/search', () => ({
   getRecommendationsAction: vi.fn(),
 }));
+
+// Mock ResizeObserver which is needed for Radix UI components
+class ResizeObserverMock {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+global.ResizeObserver = ResizeObserverMock as any;
 
 const mockRecommendation = (overrides: Record<string, unknown> = {}) => ({
   id: 'r1',
@@ -22,6 +31,8 @@ const mockRecommendation = (overrides: Record<string, unknown> = {}) => ({
 });
 
 describe('RelatedItemsBadge', () => {
+  const user = userEvent.setup();
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -46,7 +57,7 @@ describe('RelatedItemsBadge', () => {
     });
 
     render(<RelatedItemsBadge contentId="test-1" />);
-    fireEvent.click(screen.getByRole('button', { name: /related items/i }));
+    await user.click(screen.getByRole('button', { name: /related items/i }));
 
     await waitFor(() => {
       expect(searchActions.getRecommendationsAction).toHaveBeenCalledWith('test-1', 3);
@@ -62,10 +73,12 @@ describe('RelatedItemsBadge', () => {
     );
 
     render(<RelatedItemsBadge contentId="test-1" />);
-    fireEvent.click(screen.getByRole('button', { name: /related items/i }));
+    await user.click(screen.getByRole('button', { name: /related items/i }));
 
-    const spinner = document.querySelector('.animate-spin');
-    expect(spinner).toBeInTheDocument();
+    await waitFor(() => {
+      const spinner = document.querySelector('.animate-spin');
+      expect(spinner).toBeInTheDocument();
+    });
   });
 
   it('should render related items with titles', async () => {
@@ -78,12 +91,10 @@ describe('RelatedItemsBadge', () => {
     });
 
     render(<RelatedItemsBadge contentId="test-1" />);
-    fireEvent.click(screen.getByRole('button', { name: /related items/i }));
+    await user.click(screen.getByRole('button', { name: /related items/i }));
 
-    await waitFor(() => {
-      expect(screen.getByText('Related Item 1')).toBeInTheDocument();
-      expect(screen.getByText('Related Item 2')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Related Item 1')).toBeInTheDocument();
+    expect(await screen.findByText('Related Item 2')).toBeInTheDocument();
   });
 
   it('should show similarity percentage', async () => {
@@ -95,11 +106,9 @@ describe('RelatedItemsBadge', () => {
     });
 
     render(<RelatedItemsBadge contentId="test-1" />);
-    fireEvent.click(screen.getByRole('button', { name: /related items/i }));
+    await user.click(screen.getByRole('button', { name: /related items/i }));
 
-    await waitFor(() => {
-      expect(screen.getByText('85%')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('85%')).toBeInTheDocument();
   });
 
   it('should show empty state when no related items found', async () => {
@@ -109,11 +118,9 @@ describe('RelatedItemsBadge', () => {
     });
 
     render(<RelatedItemsBadge contentId="test-1" />);
-    fireEvent.click(screen.getByRole('button', { name: /related items/i }));
+    await user.click(screen.getByRole('button', { name: /related items/i }));
 
-    await waitFor(() => {
-      expect(screen.getByText('No related items found')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('No related items found')).toBeInTheDocument();
   });
 
   it('should show error message on failure', async () => {
@@ -124,10 +131,8 @@ describe('RelatedItemsBadge', () => {
     });
 
     render(<RelatedItemsBadge contentId="test-1" />);
-    fireEvent.click(screen.getByRole('button', { name: /related items/i }));
+    await user.click(screen.getByRole('button', { name: /related items/i }));
 
-    await waitFor(() => {
-      expect(screen.getByText('Something went wrong')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
   });
 });

--- a/apps/web/components/library/RelatedItemsBadge.tsx
+++ b/apps/web/components/library/RelatedItemsBadge.tsx
@@ -1,10 +1,15 @@
 'use client';
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { Sparkles, Loader2, FileText, Link2, File } from 'lucide-react';
 import { getRecommendationsAction } from '@/app/actions/search';
 import { Button } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 
 interface RelatedItemsBadgeProps {
   contentId: string;
@@ -17,7 +22,7 @@ const typeIcons: Record<string, typeof FileText> = {
 };
 
 export function RelatedItemsBadge({ contentId }: RelatedItemsBadgeProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [items, setItems] = useState<Array<{
     id: string;
@@ -26,7 +31,10 @@ export function RelatedItemsBadge({ contentId }: RelatedItemsBadgeProps) {
     similarity: number;
   }> | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const fetchRelated = useCallback(async () => {
     if (items !== null) return; // Already fetched
@@ -48,80 +56,80 @@ export function RelatedItemsBadge({ contentId }: RelatedItemsBadgeProps) {
     }
   }, [contentId, items]);
 
-  const handleClick = () => {
-    if (!isOpen) {
-      fetchRelated();
-    }
-    setIsOpen((prev) => !prev);
-  };
-
-  // Close on outside click
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleClickOutside = (e: MouseEvent) => {
-      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [isOpen]);
-
-  return (
-    <div className="relative" ref={popoverRef}>
+  if (!mounted) {
+    return (
       <Button
         variant="ghost"
         size="sm"
-        className="h-8 w-8 p-0 transition-transform hover:scale-110"
-        onClick={handleClick}
+        className="h-8 w-8 p-0"
+        disabled
         aria-label="View related items"
-        aria-expanded={isOpen}
       >
-        <Sparkles className={cn(
-          'h-4 w-4 transition-colors',
-          isOpen ? 'text-primary' : 'text-muted-foreground hover:text-primary'
-        )} />
+        <Sparkles className="h-4 w-4 text-muted-foreground/50" />
       </Button>
+    );
+  }
 
-      {isOpen && (
-        <div className="absolute right-0 top-full z-50 mt-1 w-64 rounded-lg border bg-popover p-3 shadow-soft-lg animate-scale-in">
-          <p className="text-xs font-medium text-muted-foreground mb-2">Related Items</p>
+  return (
+    <DropdownMenu onOpenChange={(open) => open && fetchRelated()}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 w-8 p-0 transition-transform hover:scale-110"
+          aria-label="View related items"
+        >
+          <Sparkles className="h-4 w-4 text-muted-foreground hover:text-primary transition-colors" />
+        </Button>
+      </DropdownMenuTrigger>
 
-          {isLoading && (
-            <div className="flex items-center justify-center py-4">
-              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-            </div>
-          )}
+      <DropdownMenuContent
+        align="end"
+        className="w-64 p-3 shadow-soft-lg"
+        sideOffset={8}
+      >
+        <p className="text-xs font-medium text-muted-foreground mb-2 px-2">
+          {items && items.length > 0 && items.some(i => i.similarity > 0) 
+            ? 'Related Items' 
+            : 'Recent Items'}
+        </p>
 
-          {!isLoading && error && (
-            <p className="text-xs text-muted-foreground py-2">{error}</p>
-          )}
+        {isLoading && (
+          <div className="flex items-center justify-center py-4">
+            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+          </div>
+        )}
 
-          {!isLoading && !error && items && items.length === 0 && (
-            <p className="text-xs text-muted-foreground py-2">No related items found</p>
-          )}
+        {!isLoading && error && (
+          <p className="text-xs text-muted-foreground py-2 px-2 cursor-default">{error}</p>
+        )}
 
-          {!isLoading && items && items.length > 0 && (
-            <div className="space-y-2">
-              {items.map((item) => {
-                const TypeIcon = typeIcons[item.type] || FileText;
-                return (
-                  <div
-                    key={item.id}
-                    className="flex items-center gap-2 rounded-md p-1.5 text-xs hover:bg-accent transition-colors"
-                  >
-                    <TypeIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                    <span className="flex-1 truncate">{item.title}</span>
+        {!isLoading && !error && items && items.length === 0 && (
+          <p className="text-xs text-muted-foreground py-2 px-2 cursor-default">No related items found</p>
+        )}
+
+        {!isLoading && items && items.length > 0 && (
+          <div className="space-y-1">
+            {items.map((item) => {
+              const TypeIcon = typeIcons[item.type] || FileText;
+              return (
+                <DropdownMenuItem
+                  key={item.id}
+                  className="flex items-center gap-2 text-xs p-1.5 cursor-pointer"
+                >
+                  <TypeIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  <span className="flex-1 truncate">{item.title}</span>
+                  {item.similarity > 0 && (
                     <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
                       {Math.round(item.similarity * 100)}%
                     </span>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
-      )}
-    </div>
+                  )}
+                </DropdownMenuItem>
+              );
+            })}
+          </div>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/apps/web/lib/ai/embeddings.ts
+++ b/apps/web/lib/ai/embeddings.ts
@@ -277,22 +277,31 @@ export async function getRecommendations(
         c.auto_tags as "autoTags",
         c.url,
         c.created_at as "createdAt",
-        1 - (e.embedding <=> ${vectorString}::vector) as similarity
+        COALESCE(1 - (e.embedding <=> ${vectorString}::vector), 0) as similarity
       FROM ${content} c
       INNER JOIN ${embeddings} e ON c.id = e.content_id
       WHERE c.id != ${contentId}
         AND c.user_id = ${userId}
-        AND (e.embedding <=> ${vectorString}::vector) <> 'NaN'::float8
+        AND (e.embedding <=> ${vectorString}::vector) IS NOT NULL
         AND 1 - (e.embedding <=> ${vectorString}::vector) >= ${minSimilarity}
       ORDER BY e.embedding <=> ${vectorString}::vector
       LIMIT ${limit}
     `);
 
-    return (results as unknown as Record<string, unknown>[]).map((row) => ({
+    const recommendations = (results as unknown as Record<string, unknown>[]).map((row) => ({
       ...row,
       similarity: Number.isFinite(row.similarity as number) ? Number(row.similarity) : 0,
       createdAt: row.createdAt instanceof Date ? row.createdAt : new Date(row.createdAt as string),
     })) as Recommendation[];
+
+    // If no recommendations found, fall back to recent items
+    if (recommendations.length === 0) {
+      return fetchRecentContent(userId, limit).then(items => 
+        items.filter(item => item.id !== contentId).slice(0, limit)
+      );
+    }
+
+    return recommendations;
   } catch (error) {
     console.error('Error getting recommendations:', error);
     return [];


### PR DESCRIPTION
This pull request addresses the following:

- **Text Cutoff Fix:** Refactored the `RelatedItemsBadge` to use Radix UI's `DropdownMenu` instead of absolute positioning. This ensures the popover automatically adjusts its position to stay within the viewport and avoids cutting off text on the edges of the screen.
- **Hydration Error Prevention:** Added an `isMounted` state check to ensure the popover only renders on the client side, preventing Next.js hydration mismatches.
- **Smart Fallback for Missing Embeddings:** If Gemini API returns zero vectors or no similar content is found, the system now gracefully falls back to displaying the user's most recent items. The popover title dynamically changes to "Recent Items" and hides the 0% similarity indicators to keep the UI clean and helpful.
- **Updated Tests:** Refactored `RelatedItemsBadge.test.tsx` to correctly simulate `DropdownMenu` interactions using `@testing-library/user-event` and added a proper `ResizeObserver` mock.